### PR TITLE
Enabled OpenMP support for Windows

### DIFF
--- a/recipe/bld_zfp.bat
+++ b/recipe/bld_zfp.bat
@@ -9,7 +9,7 @@ cmake -G "Ninja"                               ^
   -DBUILD_ZFPY=OFF                             ^
   -DBUILD_UTILITIES=ON                         ^
   -DBUILD_CFP=ON                               ^
-  -DZFP_WITH_OPENMP=OFF                        ^
+  -DZFP_WITH_OPENMP=ON                         ^
   -DCMAKE_BUILD_TYPE:STRING=Release            ^
   -DPYTHON_INCLUDE_DIR:PATH="%PREFIX%\include" ^
   -DCMAKE_INSTALL_PREFIX="%LIBRARY_PREFIX%"    ^

--- a/recipe/bld_zfpy.bat
+++ b/recipe/bld_zfpy.bat
@@ -18,7 +18,7 @@ cmake -G "Ninja"                               ^
   -DBUILD_ZFPY=ON                              ^
   -DBUILD_UTILITIES=ON                         ^
   -DBUILD_CFP=ON                               ^
-  -DZFP_WITH_OPENMP=OFF                        ^
+  -DZFP_WITH_OPENMP=ON                         ^
   -DCMAKE_BUILD_TYPE:STRING=Release            ^
   -DPYTHON_EXECUTABLE:FILEPATH="%PYTHON%"      ^
   -DPYTHON_LIBRARY:FILEPATH="%PYTHON_LIBRARY%" ^

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -24,7 +24,7 @@ source:
     # - 109-avoid-importing-cpython-array.patch
 
 build:
-  number: 4
+  number: 5
   script: source ${RECIPE_DIR}/build_zfp.sh  # [unix]
   script: {{ RECIPE_DIR }}\bld_zfp.bat       # [win]
   run_exports:


### PR DESCRIPTION
Checklist
* [X] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [X] Bumped the build number (if the version is unchanged)

Over at https://github.com/conda-forge/imagecodecs-feedstock/pull/25 some tests are failing due to missing OpenMP support under Windows in ZFP. I first searched around a bit, and thought it might be due to only old OpenMP versions being supported by most VC versions, but after a brief test I found that ZFP seemed to compile fine with the used VC version. (Necessary OpenMP DLL is part of `vs2015_runtime` under Windows; PR to try it with conda-forge's CI)

Was there any specific reason why OpenMP was disabled on Windows?
